### PR TITLE
Read commands from stdin

### DIFF
--- a/shanghai/main.py
+++ b/shanghai/main.py
@@ -1,6 +1,7 @@
 
 import asyncio
 from pprint import pprint
+import sys
 
 from .core import Shanghai
 from .config import Configuration
@@ -11,6 +12,37 @@ def exception_handler(loop, context):
     pprint(context)
     if 'task' in context:
         context['task'].print_stack()
+
+
+async def stdin_reader(loop, input_handler):
+    try:
+        if sys.platform == 'win32':
+            # Windows can't use SelectorEventLoop.connect_read_pipe
+            # and ProactorEventLoop.connect_read_pipe apparently
+            # doesn't work with sys.* streams or files.
+            # Instead, run polling in an executor (thread).
+            # http://stackoverflow.com/questions/31510190/aysncio-cannot-read-stdin-on-windows
+            while True:
+                line = await loop.run_in_executor(None, sys.stdin.readline)
+                if not line:
+                    break
+                loop.create_task(input_handler(line))
+        else:
+            reader = asyncio.StreamReader()
+            reader_protocol = asyncio.StreamReaderProtocol(reader)
+            await loop.connect_read_pipe(lambda: reader_protocol, sys.stdin)
+
+            while True:
+                line_bytes = await reader.readline()
+                line = line_bytes.decode(sys.stdin.encoding)
+                if not line:
+                    break
+                loop.create_task(input_handler(line))
+
+        print("stdin stream closed")
+    except:
+        import traceback
+        traceback.print_exc()
 
 
 def main():
@@ -27,8 +59,22 @@ def main():
     config = Configuration.from_filename('shanghai.yaml')
     bot = Shanghai(config)
     network_tasks = list(bot.init_networks())
+    print("networks:", ", ".join(bot.networks.keys()))
+
+    async def input_handler(line):
+        if ' ' not in line:
+            return
+        nw_name, irc_line = line.split(None, 1)
+        if nw_name and irc_line:
+            if nw_name not in bot.networks:
+                print("network '{}' not found".format(nw_name))
+                return
+            network = bot.networks[nw_name]['network']
+            network.connection.sendline(irc_line)
+
     loop = asyncio.get_event_loop()
     loop.set_exception_handler(exception_handler)
+    loop.create_task(stdin_reader(loop, input_handler))
     try:
         loop.run_until_complete(asyncio.wait(network_tasks, loop=loop))
     except KeyboardInterrupt:

--- a/shanghai/main.py
+++ b/shanghai/main.py
@@ -73,6 +73,7 @@ def main():
             network.connection.sendline(irc_line)
 
     loop = asyncio.get_event_loop()
+    loop.set_debug(True)
     loop.set_exception_handler(exception_handler)
     loop.create_task(stdin_reader(loop, input_handler))
     try:


### PR DESCRIPTION
Works as you think it would. First word determines the network to send to (a list of available networks is printed at the beginning), any following text is sent to the connection direcly.

![2016-06-26_20-26-10_cmd](https://cloud.githubusercontent.com/assets/931051/16363981/492f7b84-3bdc-11e6-92e2-f7e675a10f9b.png)

This is untested on UNIX!