### PR TITLE
Add initial primitive logging capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ ENV/
 .develop
 shanghai.ini
 shanghai.yaml
+logs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install -e .
 
 before_script:
-  - flake8 .
+  - flake8 --exclude=shanghai/local.py .
 
 script:
   - py.test --cov=shanghai --cov-config .coveragerc ./tests/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 	touch .install-deps
 
 flake: .install-deps
-	flake8 .
+	flake8 --exclude=shanghai/local.py .
 
 .develop: .install-deps $(shell find shanghai -type f)
 	pip install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ruamel.yaml
+pytz==2016.6.1

--- a/shanghai.example.yaml
+++ b/shanghai.example.yaml
@@ -1,4 +1,8 @@
 
+# set global logging level
+logging:
+  level: INFO
+
 networks:
   GLOBAL:
     # serves as base for each network
@@ -17,6 +21,9 @@ networks:
       - "*!*@*bot*"
 
   freenode:
+    logging:
+      # set network wide logging level. if not specified global level is used.
+      level: DEBUG
     name: Freenode
     servers:
       irc.freenode.net:

--- a/shanghai/config.py
+++ b/shanghai/config.py
@@ -30,6 +30,9 @@ class Configuration:
     def get(self, item, default=None):
         return self._yaml.get(item, default)
 
+    def items(self):
+        return self._yaml.items()
+
     @classmethod
     def from_filename(cls, filename):
         with open(filename, 'r', encoding='utf-8') as f:

--- a/shanghai/config.py
+++ b/shanghai/config.py
@@ -27,6 +27,9 @@ class Configuration:
     def __getattr__(self, item):
         return self._yaml[item]
 
+    def get(self, item, default=None):
+        return self._yaml.get(item, default)
+
     @classmethod
     def from_filename(cls, filename):
         with open(filename, 'r', encoding='utf-8') as f:
@@ -64,6 +67,9 @@ class Configuration:
                 self._yaml.get('networks', {}).items():
             if network_key == 'GLOBAL':
                 continue
+
+            if 'logging' not in network_conf:
+                network_conf['logging'] = self._yaml.get('logging', {})
 
             if 'channels' not in network_conf:
                 network_conf['channels'] = {}

--- a/shanghai/connection.py
+++ b/shanghai/connection.py
@@ -3,7 +3,7 @@ import asyncio
 
 from .event import Event
 from .irc import Message
-from .logging import DummyLogger
+from .logging import current_logger
 
 
 class Connection:
@@ -18,14 +18,10 @@ class Connection:
             self.loop = asyncio.get_event_loop()
 
         self.writer = None
-        self.logger = DummyLogger()
-
-    def set_logger(self, logger):
-        self.logger = logger
 
     def sendline(self, line):
         self.writer.write(line.encode('utf-8') + b'\r\n')
-        self.logger.debug("<", line)
+        current_logger.debug("<", line)
 
     def sendcmd(self, command, *params):
         args = [command, *params]
@@ -53,12 +49,12 @@ class Connection:
             except UnicodeDecodeError:
                 line = line.decode('latin1')
             line = line.strip()
-            self.logger.debug(">", line)
+            current_logger.debug(">", line)
             if line:
                 try:
                     message = Message.from_line(line)
                 except Exception as exc:
-                    self.logger.exception('-->', line)
+                    current_logger.exception('-->', line)
                     raise exc
                 if message.command == 'PING':
                     self.sendcmd('PONG', *message.params)

--- a/shanghai/connection.py
+++ b/shanghai/connection.py
@@ -3,7 +3,7 @@ import asyncio
 
 from .event import Event
 from .irc import Message
-from .logging import get_logger, DummyLogger
+from .logging import DummyLogger
 
 
 class Connection:

--- a/shanghai/connection.py
+++ b/shanghai/connection.py
@@ -2,7 +2,6 @@
 import asyncio
 
 from .event import Event
-from .irc import Message
 from .logging import current_logger
 
 

--- a/shanghai/irc/message.py
+++ b/shanghai/irc/message.py
@@ -1,6 +1,5 @@
 
 from .server_reply import ServerReply
-from ..logging import get_logger
 
 
 _ESCAPE_SEQUENCES = {

--- a/shanghai/irc/message.py
+++ b/shanghai/irc/message.py
@@ -1,5 +1,6 @@
 
 from .server_reply import ServerReply
+from ..logging import current_logger
 
 
 _ESCAPE_SEQUENCES = {
@@ -84,11 +85,7 @@ class Message:
             try:
                 command = ServerReply(command)
             except ValueError:
-                # TODO: how to add logging here? we currently don't have any
-                # context in messages, so we might have to reraise the error
-                # and let the parent network handle the "parse error", since
-                # it's related to the network.
-                print("unknown server reply code", command)
+                current_logger.warning("unknown server reply code", command)
 
         params = []
         if line:

--- a/shanghai/irc/message.py
+++ b/shanghai/irc/message.py
@@ -1,5 +1,6 @@
 
 from .server_reply import ServerReply
+from ..logging import get_logger
 
 
 _ESCAPE_SEQUENCES = {
@@ -84,6 +85,10 @@ class Message:
             try:
                 command = ServerReply(command)
             except ValueError:
+                # TODO: how to add logging here? we currently don't have any
+                # context in messages, so we might have to reraise the error
+                # and let the parent network handle the "parse error", since
+                # it's related to the network.
                 print("unknown server reply code", command)
 
         params = []

--- a/shanghai/local.py
+++ b/shanghai/local.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+"""
+    werkzeug.local
+    ~~~~~~~~~~~~~~
+
+    This module implements context-local objects.
+
+    :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+import copy
+
+# since each thread has its own greenlet we can just use those as identifiers
+# for the context.  If greenlets are not available we fall back to the
+# current thread ident depending on where it is.
+try:
+    from greenlet import getcurrent as get_ident
+except ImportError:
+    try:
+        from thread import get_ident
+    except ImportError:
+        from _thread import get_ident
+
+
+def release_local(local):
+    """Releases the contents of the local for the current context.
+    This makes it possible to use locals without a manager.
+
+    Example::
+
+        >>> loc = Local()
+        >>> loc.foo = 42
+        >>> release_local(loc)
+        >>> hasattr(loc, 'foo')
+        False
+
+    With this function one can release :class:`Local` objects as well
+    as :class:`LocalStack` objects.  However it is not possible to
+    release data held by proxies that way, one always has to retain
+    a reference to the underlying local object in order to be able
+    to release it.
+
+    .. versionadded:: 0.6.1
+    """
+    local.__release_local__()
+
+
+class Local(object):
+    __slots__ = ('__storage__', '__ident_func__')
+
+    def __init__(self):
+        object.__setattr__(self, '__storage__', {})
+        object.__setattr__(self, '__ident_func__', get_ident)
+
+    def __iter__(self):
+        return iter(self.__storage__.items())
+
+    def __call__(self, proxy):
+        """Create a proxy for a name."""
+        return LocalProxy(self, proxy)
+
+    def __release_local__(self):
+        self.__storage__.pop(self.__ident_func__(), None)
+
+    def __getattr__(self, name):
+        try:
+            return self.__storage__[self.__ident_func__()][name]
+        except KeyError:
+            raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        ident = self.__ident_func__()
+        storage = self.__storage__
+        try:
+            storage[ident][name] = value
+        except KeyError:
+            storage[ident] = {name: value}
+
+    def __delattr__(self, name):
+        try:
+            del self.__storage__[self.__ident_func__()][name]
+        except KeyError:
+            raise AttributeError(name)
+
+
+class LocalStack(object):
+
+    """This class works similar to a :class:`Local` but keeps a stack
+    of objects instead.  This is best explained with an example::
+
+        >>> ls = LocalStack()
+        >>> ls.push(42)
+        >>> ls.top
+        42
+        >>> ls.push(23)
+        >>> ls.top
+        23
+        >>> ls.pop()
+        23
+        >>> ls.top
+        42
+
+    They can be force released by using a :class:`LocalManager` or with
+    the :func:`release_local` function but the correct way is to pop the
+    item from the stack after using.  When the stack is empty it will
+    no longer be bound to the current context (and as such released).
+
+    By calling the stack without arguments it returns a proxy that resolves to
+    the topmost item on the stack.
+
+    .. versionadded:: 0.6.1
+    """
+
+    def __init__(self):
+        self._local = Local()
+
+    def __release_local__(self):
+        self._local.__release_local__()
+
+    def _get__ident_func__(self):
+        return self._local.__ident_func__
+
+    def _set__ident_func__(self, value):
+        object.__setattr__(self._local, '__ident_func__', value)
+    __ident_func__ = property(_get__ident_func__, _set__ident_func__)
+    del _get__ident_func__, _set__ident_func__
+
+    def __call__(self):
+        def _lookup():
+            rv = self.top
+            if rv is None:
+                raise RuntimeError('object unbound')
+            return rv
+        return LocalProxy(_lookup)
+
+    def push(self, obj):
+        """Pushes a new item to the stack"""
+        rv = getattr(self._local, 'stack', None)
+        if rv is None:
+            self._local.stack = rv = []
+        rv.append(obj)
+        return rv
+
+    def pop(self):
+        """Removes the topmost item from the stack, will return the
+        old value or `None` if the stack was already empty.
+        """
+        stack = getattr(self._local, 'stack', None)
+        if stack is None:
+            return None
+        elif len(stack) == 1:
+            release_local(self._local)
+            return stack[-1]
+        else:
+            return stack.pop()
+
+    @property
+    def top(self):
+        """The topmost item on the stack.  If the stack is empty,
+        `None` is returned.
+        """
+        try:
+            return self._local.stack[-1]
+        except (AttributeError, IndexError):
+            return None
+
+
+class LocalProxy(object):
+
+    """Acts as a proxy for a werkzeug local.  Forwards all operations to
+    a proxied object.  The only operations not supported for forwarding
+    are right handed operands and any kind of assignment.
+
+    Example usage::
+
+        from werkzeug.local import Local
+        l = Local()
+
+        # these are proxies
+        request = l('request')
+        user = l('user')
+
+
+        from werkzeug.local import LocalStack
+        _response_local = LocalStack()
+
+        # this is a proxy
+        response = _response_local()
+
+    Whenever something is bound to l.user / l.request the proxy objects
+    will forward all operations.  If no object is bound a :exc:`RuntimeError`
+    will be raised.
+
+    To create proxies to :class:`Local` or :class:`LocalStack` objects,
+    call the object as shown above.  If you want to have a proxy to an
+    object looked up by a function, you can (as of Werkzeug 0.6.1) pass
+    a function to the :class:`LocalProxy` constructor::
+
+        session = LocalProxy(lambda: get_current_request().session)
+
+    .. versionchanged:: 0.6.1
+       The class can be instantiated with a callable as well now.
+    """
+    __slots__ = ('__local', '__dict__', '__name__', '__wrapped__')
+
+    def __init__(self, local, name=None):
+        object.__setattr__(self, '_LocalProxy__local', local)
+        object.__setattr__(self, '__name__', name)
+        if callable(local) and not hasattr(local, '__release_local__'):
+            # "local" is a callable that is not an instance of Local or
+            # LocalManager: mark it as a wrapped function.
+            object.__setattr__(self, '__wrapped__', local)
+
+    def _get_current_object(self):
+        """Return the current object.  This is useful if you want the real
+        object behind the proxy at a time for performance reasons or because
+        you want to pass the object into a different context.
+        """
+        if not hasattr(self.__local, '__release_local__'):
+            return self.__local()
+        try:
+            return getattr(self.__local, self.__name__)
+        except AttributeError:
+            raise RuntimeError('no object bound to %s' % self.__name__)
+
+    @property
+    def __dict__(self):
+        try:
+            return self._get_current_object().__dict__
+        except RuntimeError:
+            raise AttributeError('__dict__')
+
+    def __repr__(self):
+        try:
+            obj = self._get_current_object()
+        except RuntimeError:
+            return '<%s unbound>' % self.__class__.__name__
+        return repr(obj)
+
+    def __bool__(self):
+        try:
+            return bool(self._get_current_object())
+        except RuntimeError:
+            return False
+
+    def __unicode__(self):
+        try:
+            return unicode(self._get_current_object())  # noqa
+        except RuntimeError:
+            return repr(self)
+
+    def __dir__(self):
+        try:
+            return dir(self._get_current_object())
+        except RuntimeError:
+            return []
+
+    def __getattr__(self, name):
+        if name == '__members__':
+            return dir(self._get_current_object())
+        return getattr(self._get_current_object(), name)
+
+    def __setitem__(self, key, value):
+        self._get_current_object()[key] = value
+
+    def __delitem__(self, key):
+        del self._get_current_object()[key]
+
+    __setattr__ = lambda x, n, v: setattr(x._get_current_object(), n, v)
+    __delattr__ = lambda x, n: delattr(x._get_current_object(), n)
+    __str__ = lambda x: str(x._get_current_object())
+    __lt__ = lambda x, o: x._get_current_object() < o
+    __le__ = lambda x, o: x._get_current_object() <= o
+    __eq__ = lambda x, o: x._get_current_object() == o
+    __ne__ = lambda x, o: x._get_current_object() != o
+    __gt__ = lambda x, o: x._get_current_object() > o
+    __ge__ = lambda x, o: x._get_current_object() >= o
+    __cmp__ = lambda x, o: cmp(x._get_current_object(), o)  # noqa
+    __hash__ = lambda x: hash(x._get_current_object())
+    __call__ = lambda x, *a, **kw: x._get_current_object()(*a, **kw)
+    __len__ = lambda x: len(x._get_current_object())
+    __getitem__ = lambda x, i: x._get_current_object()[i]
+    __iter__ = lambda x: iter(x._get_current_object())
+    __contains__ = lambda x, i: i in x._get_current_object()
+    __add__ = lambda x, o: x._get_current_object() + o
+    __sub__ = lambda x, o: x._get_current_object() - o
+    __mul__ = lambda x, o: x._get_current_object() * o
+    __floordiv__ = lambda x, o: x._get_current_object() // o
+    __mod__ = lambda x, o: x._get_current_object() % o
+    __divmod__ = lambda x, o: x._get_current_object().__divmod__(o)
+    __pow__ = lambda x, o: x._get_current_object() ** o
+    __lshift__ = lambda x, o: x._get_current_object() << o
+    __rshift__ = lambda x, o: x._get_current_object() >> o
+    __and__ = lambda x, o: x._get_current_object() & o
+    __xor__ = lambda x, o: x._get_current_object() ^ o
+    __or__ = lambda x, o: x._get_current_object() | o
+    __div__ = lambda x, o: x._get_current_object().__div__(o)
+    __truediv__ = lambda x, o: x._get_current_object().__truediv__(o)
+    __neg__ = lambda x: -(x._get_current_object())
+    __pos__ = lambda x: +(x._get_current_object())
+    __abs__ = lambda x: abs(x._get_current_object())
+    __invert__ = lambda x: ~(x._get_current_object())
+    __complex__ = lambda x: complex(x._get_current_object())
+    __int__ = lambda x: int(x._get_current_object())
+    __long__ = lambda x: long(x._get_current_object())  # noqa
+    __float__ = lambda x: float(x._get_current_object())
+    __oct__ = lambda x: oct(x._get_current_object())
+    __hex__ = lambda x: hex(x._get_current_object())
+    __index__ = lambda x: x._get_current_object().__index__()
+    __coerce__ = lambda x, o: x._get_current_object().__coerce__(x, o)
+    __enter__ = lambda x: x._get_current_object().__enter__()
+    __exit__ = lambda x, *a, **kw: x._get_current_object().__exit__(*a, **kw)
+    __radd__ = lambda x, o: o + x._get_current_object()
+    __rsub__ = lambda x, o: o - x._get_current_object()
+    __rmul__ = lambda x, o: o * x._get_current_object()
+    __rdiv__ = lambda x, o: o / x._get_current_object()
+    __rtruediv__ = __rdiv__
+    __rfloordiv__ = lambda x, o: o // x._get_current_object()
+    __rmod__ = lambda x, o: o % x._get_current_object()
+    __rdivmod__ = lambda x, o: x._get_current_object().__rdivmod__(o)
+    __copy__ = lambda x: copy.copy(x._get_current_object())
+    __deepcopy__ = lambda x, memo: copy.deepcopy(x._get_current_object(), memo)

--- a/shanghai/logging.py
+++ b/shanghai/logging.py
@@ -11,6 +11,14 @@ import pytz
 from .local import LocalStack, LocalProxy
 
 
+_LOGGING_CONFIG = {}
+
+
+def set_logging_config(config):
+    global _LOGGING_CONFIG
+    _LOGGING_CONFIG = config
+
+
 def _print_like(func):
     @functools.wraps(func)
     def _wrap(self, *args):
@@ -80,7 +88,7 @@ class LogContext:
     def __init__(self, context, name, config=None):
         self.context = context
         self.name = name
-        self.config = {} if config is None else config
+        self.config = _LOGGING_CONFIG if config is None else config
         self.logger = None
 
     def __enter__(self):

--- a/shanghai/logging.py
+++ b/shanghai/logging.py
@@ -122,6 +122,8 @@ class LogContext:
 
         tzname = os.environ.get('TZ', None)
 
+        config = {**_LOGGING_CONFIG, **config}
+
         if tzname is None:
             tzname = config.get('timezone', None)
 

--- a/shanghai/logging.py
+++ b/shanghai/logging.py
@@ -1,0 +1,132 @@
+
+from datetime import datetime
+import functools
+import hashlib
+import io
+import logging
+import os
+
+import pytz
+
+
+class FileHandler(logging.FileHandler):
+
+    def __init__(self, filename):
+        filename = os.path.abspath(filename)
+        basedir = os.path.dirname(filename)
+        os.makedirs(basedir, 0o755, exist_ok=True)
+        super().__init__(filename, 'a', 'utf-8', None)
+
+
+class Formatter(logging.Formatter):
+
+    def __init__(self, context, name, tz):
+        super().__init__()
+        self._context = context
+        self._name = name
+        self._tz = tz
+
+    def format(self, record: logging.LogRecord):
+        now = datetime.now(tz=self._tz)
+        data = dict(
+            context=self._context,
+            name=self._name,
+            message=record.getMessage(),
+            level=record.levelname,
+            date=now,
+        )
+        s = '{context}/{name} - {level} [{date:%Y-%m-%d %H:%M:%S %z}]' \
+            ' {message}'.format(**data)
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            if s[-1:] != "\n":
+                s += "\n"
+            s = s + record.exc_text
+        if record.stack_info:
+            if s[-1:] != "\n":
+                s += "\n"
+            s = s + self.formatStack(record.stack_info)
+        return s
+
+
+def _print_like(func):
+    @functools.wraps(func)
+    def _wrap(self, *args):
+        f = io.StringIO()
+        print(*args, file=f)
+        return func(self, f.getvalue().strip())
+    return _wrap
+
+
+class DummyLogger:
+    def _dummy(self, *args, **kwargs):
+        pass
+    log = _dummy
+    info = _dummy
+    debug = _dummy
+    warn = _dummy
+    warning = _dummy
+    error = _dummy
+    exception = _dummy
+
+
+class Logger(logging.Logger):
+    """Wrap _print_link around so we can use logger.info etc. similar to the
+    print function. e.g. logging.info('foo', 'bar', 'baz')"""
+    info = _print_like(logging.Logger.info)
+    debug = _print_like(logging.Logger.debug)
+    warn = _print_like(logging.Logger.warn)
+    warning = _print_like(logging.Logger.warning)
+    error = _print_like(logging.Logger.error)
+    exception = _print_like(logging.Logger.exception)
+
+
+def get_logger(context, name, config):
+    """
+    context: i.e. 'network', 'channel', 'core', whatvever.
+    name: some preferably unique name inside of context
+          e.g. 'freenode' in context 'network'
+    """
+    logging.setLoggerClass(Logger)
+    hashed_name = hashlib.sha256(name.lower().encode('utf-8')).hexdigest()[:12]
+    logger = logging.getLogger('{}.{}'.format(context.lower(), hashed_name))
+
+    tzname = config.get('timezone', None)
+    if tzname is None and os.path.exists('/etc/timezone'):
+        with open('/etc/timezone', 'r') as f:
+            tzname = f.read().strip()
+
+    if tzname is None:
+        tzname = 'UTC'
+
+    timezone = pytz.timezone(tzname)
+    now = datetime.now(tz=timezone)
+    name_attributes = dict(
+        context=context,
+        name=name,
+        date=now
+    )
+
+    file_handler = FileHandler(
+        'logs/{context}-{name}-{date:%Y-%m}.log'.format(**name_attributes))
+    stream_handler = logging.StreamHandler()
+
+    formatter = Formatter(context, name, tz=timezone)
+
+    file_handler.setFormatter(formatter)
+    stream_handler.setFormatter(formatter)
+
+    logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
+
+    level = config.get('logging', {}).get('level', 'INFO')
+    logger.setLevel(level)
+
+    logger.info('*'*50)
+    logger.info('Opened log.'.format(date=now))
+
+    return logger

--- a/shanghai/logging.py
+++ b/shanghai/logging.py
@@ -8,6 +8,28 @@ import os
 
 import pytz
 
+from .local import LocalStack, LocalProxy
+
+
+def _print_like(func):
+    @functools.wraps(func)
+    def _wrap(self, *args):
+        f = io.StringIO()
+        print(*args, file=f)
+        return func(self, f.getvalue().strip())
+    return _wrap
+
+
+class Logger(logging.Logger):
+    """Wrap _print_link around so we can use logger.info etc. similar to the
+    print function. e.g. logging.info('foo', 'bar', 'baz')"""
+    info = _print_like(logging.Logger.info)
+    debug = _print_like(logging.Logger.debug)
+    warn = _print_like(logging.Logger.warn)
+    warning = _print_like(logging.Logger.warning)
+    error = _print_like(logging.Logger.error)
+    exception = _print_like(logging.Logger.exception)
+
 
 class FileHandler(logging.FileHandler):
 
@@ -53,80 +75,86 @@ class Formatter(logging.Formatter):
         return s
 
 
-def _print_like(func):
-    @functools.wraps(func)
-    def _wrap(self, *args):
-        f = io.StringIO()
-        print(*args, file=f)
-        return func(self, f.getvalue().strip())
-    return _wrap
+class LogContext:
+
+    def __init__(self, context, name, config=None):
+        self.context = context
+        self.name = name
+        self.config = {} if config is None else config
+        self.logger = None
+
+    def __enter__(self):
+        self.push()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.pop()
+
+    def push(self):
+        if self.logger is None:
+            self.logger = self._get_logger(
+                self.context, self.name, self.config)
+        _logging_ctx_stack.push(self)
+
+    def pop(self):
+        _logging_ctx_stack.pop()
+
+    @staticmethod
+    def _get_logger(context, name, config):
+        """
+        context: i.e. 'network', 'channel', 'core', whatvever.
+        name: some preferably unique name inside of context
+              e.g. 'freenode' in context 'network'
+        """
+        logging.setLoggerClass(Logger)
+        # use a hashed version to avoid it containing dots.
+        hashed_name = hashlib.sha256(
+            name.lower().encode('utf-8')).hexdigest()[:12]
+        logger = logging.getLogger(
+            '{}.{}'.format(context.lower(), hashed_name))
+
+        tzname = config.get('timezone', None)
+        if tzname is None and os.path.exists('/etc/timezone'):
+            with open('/etc/timezone', 'r') as f:
+                tzname = f.read().strip()
+
+        if tzname is None:
+            tzname = 'UTC'
+
+        timezone = pytz.timezone(tzname)
+        now = datetime.now(tz=timezone)
+        name_attributes = dict(
+            context=context,
+            name=name,
+            date=now
+        )
+
+        file_handler = FileHandler(
+            'logs/{context}-{name}-{date:%Y-%m}.log'.format(**name_attributes))
+        stream_handler = logging.StreamHandler()
+
+        formatter = Formatter(context, name, tz=timezone)
+
+        file_handler.setFormatter(formatter)
+        stream_handler.setFormatter(formatter)
+
+        logger.addHandler(file_handler)
+        logger.addHandler(stream_handler)
+
+        level = config.get('logging', {}).get('level', 'INFO')
+        logger.setLevel(level)
+
+        logger.info('*'*50)
+        logger.info('Opened log.'.format(date=now))
+
+        return logger
 
 
-class DummyLogger:
-    def _dummy(self, *args, **kwargs):
-        pass
-    log = _dummy
-    info = _dummy
-    debug = _dummy
-    warn = _dummy
-    warning = _dummy
-    error = _dummy
-    exception = _dummy
+def _get_current_logger():
+    top = _logging_ctx_stack.top
+    if top is None:
+        raise RuntimeError("Working outside logging context")
+    return top.logger
 
 
-class Logger(logging.Logger):
-    """Wrap _print_link around so we can use logger.info etc. similar to the
-    print function. e.g. logging.info('foo', 'bar', 'baz')"""
-    info = _print_like(logging.Logger.info)
-    debug = _print_like(logging.Logger.debug)
-    warn = _print_like(logging.Logger.warn)
-    warning = _print_like(logging.Logger.warning)
-    error = _print_like(logging.Logger.error)
-    exception = _print_like(logging.Logger.exception)
-
-
-def get_logger(context, name, config):
-    """
-    context: i.e. 'network', 'channel', 'core', whatvever.
-    name: some preferably unique name inside of context
-          e.g. 'freenode' in context 'network'
-    """
-    logging.setLoggerClass(Logger)
-    hashed_name = hashlib.sha256(name.lower().encode('utf-8')).hexdigest()[:12]
-    logger = logging.getLogger('{}.{}'.format(context.lower(), hashed_name))
-
-    tzname = config.get('timezone', None)
-    if tzname is None and os.path.exists('/etc/timezone'):
-        with open('/etc/timezone', 'r') as f:
-            tzname = f.read().strip()
-
-    if tzname is None:
-        tzname = 'UTC'
-
-    timezone = pytz.timezone(tzname)
-    now = datetime.now(tz=timezone)
-    name_attributes = dict(
-        context=context,
-        name=name,
-        date=now
-    )
-
-    file_handler = FileHandler(
-        'logs/{context}-{name}-{date:%Y-%m}.log'.format(**name_attributes))
-    stream_handler = logging.StreamHandler()
-
-    formatter = Formatter(context, name, tz=timezone)
-
-    file_handler.setFormatter(formatter)
-    stream_handler.setFormatter(formatter)
-
-    logger.addHandler(file_handler)
-    logger.addHandler(stream_handler)
-
-    level = config.get('logging', {}).get('level', 'INFO')
-    logger.setLevel(level)
-
-    logger.info('*'*50)
-    logger.info('Opened log.'.format(date=now))
-
-    return logger
+_logging_ctx_stack = LocalStack()
+current_logger = LocalProxy(_get_current_logger)  # type: Logger

--- a/shanghai/logging.py
+++ b/shanghai/logging.py
@@ -112,10 +112,16 @@ class LogContext:
         logger = logging.getLogger(
             '{}.{}'.format(context.lower(), hashed_name))
 
-        tzname = config.get('timezone', None)
-        if tzname is None and os.path.exists('/etc/timezone'):
-            with open('/etc/timezone', 'r') as f:
-                tzname = f.read().strip()
+        tzname = os.environ.get('TZ', None)
+
+        if tzname is None:
+            tzname = config.get('timezone', None)
+
+        if tzname is None:
+            tzfile = '/etc/timezone'
+            if os.path.exists(tzfile) and os.path.isfile(tzfile):
+                with open(tzfile, 'r') as f:
+                    tzname = f.read().strip()
 
         if tzname is None:
             tzname = 'UTC'

--- a/shanghai/logging.py
+++ b/shanghai/logging.py
@@ -144,17 +144,22 @@ class LogContext:
             date=now
         )
 
-        file_handler = FileHandler(
-            'logs/{context}-{name}-{date:%Y-%m}.log'.format(**name_attributes))
-        stream_handler = logging.StreamHandler()
-
         formatter = Formatter(context, name, tz=timezone)
 
-        file_handler.setFormatter(formatter)
-        stream_handler.setFormatter(formatter)
+        disable_logging = config.get('disable-logging', False)
+        disable_logging_output = config.get('disable-logging-output', False)
 
-        logger.addHandler(file_handler)
-        logger.addHandler(stream_handler)
+        if not disable_logging:
+            file_handler = FileHandler(
+                'logs/{context}-{name}-{date:%Y-%m}.log'
+                .format(**name_attributes))
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+
+        if not disable_logging_output:
+            stream_handler = logging.StreamHandler()
+            stream_handler.setFormatter(formatter)
+            logger.addHandler(stream_handler)
 
         level = config.get('logging', {}).get('level', 'INFO')
         logger.setLevel(level)

--- a/shanghai/logging.py
+++ b/shanghai/logging.py
@@ -89,7 +89,7 @@ class LogContext:
         self.context = context
         self.name = name
         self.config = _LOGGING_CONFIG if config is None else config
-        self.logger = None
+        self.logger = self._get_logger(self.context, self.name, self.config)
 
     def __enter__(self):
         self.push()
@@ -98,9 +98,6 @@ class LogContext:
         self.pop()
 
     def push(self):
-        if self.logger is None:
-            self.logger = self._get_logger(
-                self.context, self.name, self.config)
         _logging_ctx_stack.push(self)
 
     def pop(self):

--- a/shanghai/main.py
+++ b/shanghai/main.py
@@ -4,7 +4,7 @@ from pprint import pprint
 
 from .core import Shanghai
 from .config import Configuration
-from .logging import current_logger, LogContext
+from .logging import current_logger, LogContext, set_logging_config
 
 
 def exception_handler(loop, context):
@@ -19,7 +19,9 @@ def exception_handler(loop, context):
 
 def main():
     config = Configuration.from_filename('shanghai.yaml')
-    with LogContext('shanghai', 'main.py', config):
+    set_logging_config({key: value for key, value in config.items() if
+                        key in ('logging', 'timezone')})
+    with LogContext('shanghai', 'main.py'):
 
         try:
             import uvloop

--- a/shanghai/main.py
+++ b/shanghai/main.py
@@ -9,11 +9,9 @@ from .logging import current_logger, LogContext
 
 def exception_handler(loop, context):
     import io
-    import contextlib
     f = io.StringIO()
-    with contextlib.redirect_stdout(f):
-        print("exception_handler context:")
-        pprint(context)
+    print("exception_handler context:", file=f)
+    pprint(context, stream=f)
     current_logger.error(f.getvalue())
     if 'task' in context:
         context['task'].print_stack()

--- a/shanghai/main.py
+++ b/shanghai/main.py
@@ -4,10 +4,7 @@ from pprint import pprint
 
 from .core import Shanghai
 from .config import Configuration
-from .logging import get_logger
-
-
-core_logger = None
+from .logging import current_logger, LogContext
 
 
 def exception_handler(loop, context):
@@ -17,39 +14,38 @@ def exception_handler(loop, context):
     with contextlib.redirect_stdout(f):
         print("exception_handler context:")
         pprint(context)
-    core_logger.error(f.getvalue())
+    current_logger.error(f.getvalue())
     if 'task' in context:
         context['task'].print_stack()
 
 
 def main():
-    global core_logger
-
     config = Configuration.from_filename('shanghai.yaml')
-    core_logger = get_logger('shanghai', 'main.py', config)
+    with LogContext('shanghai', 'main.py', config):
 
-    try:
-        import uvloop
-    except ImportError:
-        # TODO: use a proper terminal color tool in the future (e.g. colorama)
-        # ... and possibly hook it up with the logging module.
-        core_logger.debug('\033[32;1mUsing default event loop.\033[0m')
-    else:
-        core_logger.debug('\033[32;1mUsing uvloop event loop.\033[0m')
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        try:
+            import uvloop
+        except ImportError:
+            # TODO: use a proper terminal color tool in the future (e.g.
+            # colorama) ... and possibly hook it up with the logging module.
+            current_logger.debug('\033[32;1mUsing default event loop.\033[0m')
+        else:
+            current_logger.debug('\033[32;1mUsing uvloop event loop.\033[0m')
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
-    bot = Shanghai(config)
-    network_tasks = list(bot.init_networks())
-    loop = asyncio.get_event_loop()
-    loop.set_exception_handler(exception_handler)
-    try:
-        loop.run_until_complete(asyncio.wait(network_tasks, loop=loop))
-    except KeyboardInterrupt:
-        core_logger.info("[!] cancelled by user")
-        # schedule close event
-        task = asyncio.wait([n['network'].stop_running("KeyboardInterrupt")
-                             for n in bot.networks.values()],
-                            loop=loop)
-        loop.run_until_complete(task)
-        # wait again until networks have disconnected
-        loop.run_until_complete(asyncio.wait(network_tasks, loop=loop))
+        bot = Shanghai(config)
+        network_tasks = list(bot.init_networks())
+        loop = asyncio.get_event_loop()
+        loop.set_exception_handler(exception_handler)
+        try:
+            loop.run_until_complete(asyncio.wait(network_tasks, loop=loop))
+        except KeyboardInterrupt:
+            current_logger.info("[!] cancelled by user")
+            # schedule close event
+            task = asyncio.wait([n['network'].stop_running("KeyboardInterrupt")
+                                 for n in bot.networks.values()],
+                                loop=loop)
+            loop.run_until_complete(task)
+            # wait again until networks have disconnected
+            loop.run_until_complete(asyncio.wait(network_tasks, loop=loop))
+        current_logger.info('Closing now.')

--- a/shanghai/main.py
+++ b/shanghai/main.py
@@ -4,27 +4,40 @@ from pprint import pprint
 
 from .core import Shanghai
 from .config import Configuration
+from .logging import get_logger
+
+
+core_logger = None
 
 
 def exception_handler(loop, context):
-    print("exception_handler context:")
-    pprint(context)
+    import io
+    import contextlib
+    f = io.StringIO()
+    with contextlib.redirect_stdout(f):
+        print("exception_handler context:")
+        pprint(context)
+    core_logger.error(f.getvalue())
     if 'task' in context:
         context['task'].print_stack()
 
 
 def main():
+    global core_logger
+
+    config = Configuration.from_filename('shanghai.yaml')
+    core_logger = get_logger('shanghai', 'main.py', config)
+
     try:
         import uvloop
     except ImportError:
         # TODO: use a proper terminal color tool in the future (e.g. colorama)
         # ... and possibly hook it up with the logging module.
-        print('\033[32;1mUsing default event loop.\033[0m')
+        core_logger.debug('\033[32;1mUsing default event loop.\033[0m')
     else:
-        print('\033[32;1mUsing uvloop event loop.\033[0m')
+        core_logger.debug('\033[32;1mUsing uvloop event loop.\033[0m')
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
-    config = Configuration.from_filename('shanghai.yaml')
     bot = Shanghai(config)
     network_tasks = list(bot.init_networks())
     loop = asyncio.get_event_loop()
@@ -32,7 +45,7 @@ def main():
     try:
         loop.run_until_complete(asyncio.wait(network_tasks, loop=loop))
     except KeyboardInterrupt:
-        print("[!] cancelled by user")
+        core_logger.info("[!] cancelled by user")
         # schedule close event
         task = asyncio.wait([n['network'].stop_running("KeyboardInterrupt")
                              for n in bot.networks.values()],

--- a/shanghai/network.py
+++ b/shanghai/network.py
@@ -38,7 +38,7 @@ class Network:
         self.current_server_index = -1
         self.queue = None
         self.connection = None
-        self.log_context = None
+        self.log_context = LogContext('network', self.name, self.config)
         self.reset()
 
     def reset(self):
@@ -67,7 +67,6 @@ class Network:
         return server
 
     async def run(self):
-        self.log_context = LogContext('network', self.name, self.config)
         self.log_context.push()
 
         def cancel_other_task_if_failed(task, other_task):

--- a/shanghai/network.py
+++ b/shanghai/network.py
@@ -122,7 +122,7 @@ class Network:
         # as its value
         event = await self.queue.get()
         if event.name == 'close_now':
-            print(self.name, 'Closing prematurely')
+            current_logger.info('closing connection prematurely!')
             # force runner task to except as well, because we got "close_now"
             # before "connected" a connection might not be established yet.
             # So we set an exception instead of closing the connection.

--- a/shanghai/network.py
+++ b/shanghai/network.py
@@ -96,7 +96,8 @@ class Network:
 
             # We didn't stop, so try to reconnect
             seconds = 30 * retry
-            current_logger.info('Retry connecting in {} seconds'.format(seconds))
+            current_logger.info(
+                'Retry connecting in {} seconds'.format(seconds))
             await asyncio.sleep(seconds)
             self.reset()
         self.log_context.pop()

--- a/shanghai/network.py
+++ b/shanghai/network.py
@@ -7,7 +7,6 @@ import re
 from .connection import Connection
 from .event import Event
 from .irc import Message, Options, ServerReply
-from .irc import Options, ServerReply
 from .logging import LogContext, current_logger
 
 
@@ -149,8 +148,7 @@ class Network:
                 try:
                     message = Message.from_line(line)
                 except Exception as exc:
-                    print('EXCEPTION!', exc)
-                    print('--> ', line)
+                    current_logger.exception('-->', line)
                     raise exc
                 if message.command == 'PING':
                     self.sendcmd('PONG', *message.params)

--- a/shanghai/network.py
+++ b/shanghai/network.py
@@ -7,7 +7,7 @@ import re
 from .connection import Connection
 from .event import Event
 from .irc import Options, ServerReply
-from .logging import get_logger
+from .logging import LogContext, current_logger
 
 
 class Context:
@@ -38,10 +38,10 @@ class Network:
         self.current_server_index = -1
         self.queue = None
         self.connection = None
+        self.log_context = None
         self.reset()
 
     def reset(self):
-        self.logger = get_logger('network', self.name, self.config)
 
         self.registered = False
         self.nickname = None
@@ -57,19 +57,21 @@ class Network:
         self.queue = asyncio.Queue()
         self.connection = Connection(server.host, server.port, self.queue,
                                      server.ssl)
-        self.connection.set_logger(self.logger)
 
     def next_server(self):
         servers = self.config['servers']
         self.current_server_index = ((self.current_server_index + 1)
                                      % len(servers))
         server = servers[self.current_server_index]
-        self.logger.info(self.name, 'Using server', server)
+        current_logger.info(self.name, 'Using server', server)
         return server
 
     async def run(self):
+        self.log_context = LogContext('network', self.name, self.config)
+        self.log_context.push()
+
         def cancel_other_task_if_failed(task, other_task):
-            self.logger.info('cancel_other_task_if_failed', task)
+            current_logger.info('cancel_other_task_if_failed', task)
             if task.exception():
                 task.print_stack()
                 other_task.cancel()
@@ -89,13 +91,15 @@ class Network:
                                               self.worker_task,
                                               return_exceptions=True)
             if stopped is True:
+                self.log_context.pop()
                 return
 
             # We didn't stop, so try to reconnect
             seconds = 30 * retry
-            self.logger.info('Retry connecting in {} seconds'.format(seconds))
+            current_logger.info('Retry connecting in {} seconds'.format(seconds))
             await asyncio.sleep(seconds)
             self.reset()
+        self.log_context.pop()
 
     def start_register(self):
         # testing
@@ -119,20 +123,20 @@ class Network:
         event = await self.queue.get()
         assert event.name == "connected"
         # self.connection = event.value
-        self.logger.info(event)
+        current_logger.info(event)
         stopped = False
 
         # start register process
         self.start_register()
         while True:
             event = await self.queue.get()
-            self.logger.debug(event)
+            current_logger.debug(event)
             # remember to forward these event to plugins
             if event.name == 'disconnected':
-                self.logger.info('connection closed by peer!')
+                current_logger.info('connection closed by peer!')
                 break
             elif event.name == 'close_now':
-                self.logger.info('closing connection!')
+                current_logger.info('closing connection!')
                 await self.connection.close(event.value)
                 stopped = True
                 break
@@ -169,5 +173,5 @@ class Network:
             # TODO: dispatch event to handlers, e.g. plugins.
             # TODO: pass the context along
 
-        self.logger.info('exiting.')
+        current_logger.info('exiting.')
         return stopped

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,21 +1,21 @@
 
 from unittest import TestCase
 from shanghai.irc import Message, ServerReply
-# from shanghai.logging import LogContext, set_logging_config
+from shanghai.logging import LogContext, set_logging_config
 
 
 class TestMessage(TestCase):
 
     def setUp(self):
-        # TODO: implement disable logging option
-        # set_logging_config({'disable-logging': True})
-        # self.log_context = LogContext('test', 'test')
-        # self.log_context.push()
-        pass
+        set_logging_config({
+            'disable-logging': True,
+            'disable-logging-output': True,
+        })
+        self.log_context = LogContext('test', 'test')
+        self.log_context.push()
 
     def tearDown(self):
-        # self.log_context.pop()
-        pass
+        self.log_context.pop()
 
     def test_privmsg(self):
         m = Message.from_line(':nick!user@host PRIVMSG #channel :Some message')


### PR DESCRIPTION
As title states, adds logging capabilities.

A context and name as strings are passed to the get_logger function to create a logger and a new logging file. It's primarily so we can have multiple logs per network per channel etc.

I'm still unsure on how it's done. To be able to log practically everywhere you'd have to hand around the logger instances or some other information to be able to recreate the logger instances. For example, to get rid of the print lines in the `Connection` class I had to either create a new logging instance for that connection, which is silly, because a connection is tied to the network and should be handled by the networks logger (so it appears in the correct file) - or pass the logger to the Connection either via `__init__` or a separate method (which I did).

A similar problem is in `irc/message.py`. A `Message` shouldn't really do the logging itself, because a `Message` doesn't really know currently whether it's a channel or user and what network it's from. So a possibility would be to raise an exception and let the network handle the logging.

Another way (which I kinda like) would be to do it the Flask (web framework) way and use a global proxy object, that fetches the current logger for the current context.

The way [Flask does it](https://github.com/pallets/flask/blob/master/flask/globals.py#L58), is by using a "LocalProxy" instance that is tied to a function that gets (in this case) the current app from the top of a stack. You would push and pop from that stack whenever you enter or leave a new app context - or in our case, whenever we enter and leave a logging context.

If we do it like that, we would simply import the "current_logger" using something like: `from .logging import current_logger` or the like. And to create a new logging context we would maybe do something like: `from .logging import LogContext` create our instance with some arguments and simply: `log_context.push()` and `log_context.pop()` on entering and leaving the new logging context. Any statements like `current_logger.info('Foobar')` between the push and pop would then log using the logger that was created by the `LogContext` (somewhere in `__init__` or the like).

**Edit: also, we could do stuff like:**
```
with LogContext('channel', message.target):
    handle_channel_message(message)
```