### PR TITLE
Use tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-[run]
-# branch = True
-source =
-    shanghai
-omit =
-  shanghai/local.py
-  **/__main__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,19 @@ python:
   - "3.5"
 
 env:
-  - TOXENV=py35-coveralls
+  - TOXENV=py35
   - TOXENV=flake8
   - TOXENV=mypy
 
 install:
   - pip install tox
+  - pip install coveralls
 
 script:
   - tox
+
+after_success:
+  - coveralls
 
 notifications:
   # email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,16 @@ language: python
 python:
   - "3.5"
 
-install:
-  - pip install -r dev-requirements.txt
-  - pip install coveralls
-  - pip install -e .
+env:
+  - TOXENV=py35-coveralls
+  - TOXENV=flake8
+  - TOXENV=mypy
 
-before_script:
-  - flake8 --exclude=shanghai/local.py .
+install:
+  - pip install tox
 
 script:
-  - py.test --cov=shanghai --cov-config .coveragerc ./tests/
-
-after_success:
-  - coverage xml
-  - coveralls
+  - tox
 
 notifications:
   # email: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,12 @@
 [bdist_wheel]
 universal = 1
 
-[flake8]
-exclude = venv/
+# TODO move to tox.ini
+# once https://bitbucket.org/ned/coveragepy/issues/519 is closed.
+[coverage:run]
+# branch = True
+source =
+    shanghai
+omit =
+  shanghai/local.py
+  **/__main__.py

--- a/tox.ini
+++ b/tox.ini
@@ -8,20 +8,9 @@ deps =
   pytest==3.0.1
   coverage==4.2
 commands =
-  coverage run -m pytest
+  coverage run -m pytest {posargs}
   # coverage run --rcfile tox.ini -m pytest {posargs}
   coverage report -m
-
-# coveralls report
-[testenv:py35-coveralls]
-skip_install = true
-deps =
-  {[testenv]deps}
-  coveralls
-passenv = CI TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH TRAVIS_PULL_REQUEST
-commands =
-  {[testenv]commands}
-  coveralls
 
 # Linters
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,8 @@ commands =
 norecursedirs =
   .*
   *.egg*
+  build
+  dist
   venv
   logs
 
@@ -84,8 +86,11 @@ omit =
 
 [flake8]
 exclude =
-  .*,
-  *.egg*,
+  .tox,
+  .git,
+  build,
+  dist,
+  *.egg-info,
   venv,
   __pycache__,
   shanghai/local.py,

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,8 @@ deps =
   mypy-lang
   typed_ast
 commands =
-  mypy --fast-parser {posargs} shanghai
+  # mypy is not mature enough to allow it to make builds fail
+  - mypy --fast-parser --silent-imports {posargs} shanghai
 
 # Release tooling
 [testenv:build]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,90 @@
+[tox]
+envlist = py35,flake8
+
+[testenv]
+skip_install = true
+deps =
+  -rrequirements.txt
+  pytest==3.0.1
+  coverage==4.2
+commands =
+  coverage run -m pytest
+  # coverage run --rcfile tox.ini -m pytest {posargs}
+  coverage report -m
+
+# coveralls report
+[testenv:py35-coveralls]
+skip_install = true
+deps =
+  {[testenv]deps}
+  coveralls
+passenv = CI TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH TRAVIS_PULL_REQUEST
+commands =
+  {[testenv]commands}
+  coveralls
+
+# Linters
+[testenv:flake8]
+basepython = python3.5
+skip_install = true
+deps =
+  flake8==3.0.4
+commands =
+  flake8 {posargs} .
+
+[testenv:mypy]
+# typed_ast is required for py3.5 syntax
+# but is not yet available on windows,
+# so this only works on UNIX
+platform = linux|darwin
+basepython = python3.5
+skip_install = true
+deps =
+  mypy-lang
+  typed_ast
+commands =
+  mypy --fast-parser {posargs} shanghai
+
+# Release tooling
+[testenv:build]
+basepython = python3.5
+skip_install = true
+deps =
+    wheel
+    setuptools
+commands =
+    python setup.py -q sdist bdist_wheel
+
+[testenv:release]
+basepython = python3.5
+skip_install = true
+deps =
+    {[testenv:build]deps}
+    twine>=1.5.0
+commands =
+    {[testenv:build]commands}
+    twine upload --skip-existing dist/*
+
+# Other tools
+[pytest]
+norecursedirs =
+  .*
+  *.egg*
+  venv
+  logs
+
+[coverage:run]
+# branch = True
+source =
+  shanghai
+omit =
+  shanghai/local.py
+  __main__.py
+
+[flake8]
+exclude =
+  .*,
+  *.egg*,
+  venv,
+  __pycache__,
+  shanghai/local.py,


### PR DESCRIPTION
This PR adds tox environment data to our project. I also added a mypy task for funsies, but it's not mature enough to be required for CI testing.

Closes #20.

## Advantages

- Can run one toxenv test on every CI instance (looks like [this](https://travis-ci.org/chireiden/shanghai/builds/158048545)), so that our testsuite may pass and flake8 checking may not
- linting and running environments are separate, i.e. uses its own
- Centralizes CI configuration into almost one file

## Disadvantages

- running tests is slightly slower due to package setup process, but can always invoke required commands manually if desired

---

### Short intro to tox

Install:
```
pip install tox
```

Run standard tests (test suite and flake8):
```
tox
```

Run mypy checker (not in standard tests):
```
tox -e mypy
```