### PR TITLE
Colored logging

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file dev-requirements.txt dev-requirements.in
 #
 click==6.6                # via pip-tools
-colorama==0.3.7           # via pytest
+colorama==0.3.7
 coverage==4.2
 first==2.0.1              # via pip-tools
 flake8==3.0.4

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 ruamel.yaml
 pytz==2016.6.1
+colorama

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+colorama==0.3.7
 pytz==2016.6.1
 ruamel.yaml==0.12.10

--- a/shanghai/logging.py
+++ b/shanghai/logging.py
@@ -97,10 +97,9 @@ class Formatter(logging.Formatter):
 
         s = ("{context}/{name}"
              " [{date:%Y-%m-%d %H:%M:%S %z}]"
-             " - "
-             "{color_start}"
+             " {color_start}| "
              "{level:{level_name_length}}"
-             "{message}"
+             " | {message}"
              "{color_end}"
              ).format(level_name_length=self._max_logging_level_length, **data)
         if record.exc_info:

--- a/shanghai/logging.py
+++ b/shanghai/logging.py
@@ -192,7 +192,7 @@ class LogContext:
 
         if not disable_logging_output:
             terminal_formatter = Formatter(context, name, tz=timezone,
-                                          terminal=True)
+                                           terminal=True)
             stream_handler = logging.StreamHandler()
             stream_handler.setFormatter(terminal_formatter)
             logger.addHandler(stream_handler)

--- a/shanghai/main.py
+++ b/shanghai/main.py
@@ -3,6 +3,8 @@ import asyncio
 from pprint import pprint
 import sys
 
+import colorama
+
 from .core import Shanghai
 from .config import Configuration
 from .logging import current_logger, LogContext, set_logging_config
@@ -52,6 +54,8 @@ async def stdin_reader(loop, input_handler):
 
 
 def main():
+    colorama.init()
+
     config = Configuration.from_filename('shanghai.yaml')
     set_logging_config({key: value for key, value in config.items() if
                         key in ('logging', 'timezone')})
@@ -67,7 +71,7 @@ def main():
 
         bot = Shanghai(config)
         network_tasks = list(bot.init_networks())
-        print("networks:", ", ".join(bot.networks.keys()))
+        print("\nnetworks:", ", ".join(bot.networks.keys()), end="\n\n")
 
         async def input_handler(line):
             """Handle stdin input while running. Send lines to networks."""


### PR DESCRIPTION

![2016-09-27_03-29-50_cmd](https://cloud.githubusercontent.com/assets/931051/18857246/ab9fabda-8462-11e6-97c2-2e14861bfbb1.png)

`colorama` is very easy to work with. :smile: 

Coloring only happens when logging to the terminal, i.e. stdout, not to files. Color set inspired by [this gist](https://gist.github.com/mooware/a1ed40987b6cc9ab9c65#file-colorstreamhandler-py-L109-L113).

I also re-arranged the message format to make it easier to skim. Specifically, level names are aligned and the less important parts are now at the front, i.e. the timestamp.

Closes #5.