### PR TITLE
Eat Events in Dispatchers

### DIFF
--- a/shanghai/event.py
+++ b/shanghai/event.py
@@ -141,17 +141,17 @@ class EventDispatcher:
         for priority, handlers in self.event_map[name]:
             # Use isEnabledFor because this will be called often
             is_ddebug = self.logger.isEnabledFor(LogLevels.DDEBUG)
-            if is_ddebug:
+            if is_ddebug:  # pragma: nocover
                 self.logger.ddebug("Creating tasks for event {!r} (priority {}), from {}"
                                    .format(name, priority, {repr_func(func) for func in handlers}))
             tasks = [asyncio.ensure_future(h(*args)) for h in handlers]
 
-            if is_ddebug:
+            if is_ddebug:  # pragma: nocover
                 self.logger.ddebug("Starting tasks for event {!r} (priority {}); tasks: {}"
                                    .format(name, priority, tasks))
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
-            if is_ddebug:
+            if is_ddebug:  # pragma: nocover
                 self.logger.ddebug("Results from event {!r} (priority {}): {}"
                                    .format(name, priority, results))
 

--- a/shanghai/plugins/test.py
+++ b/shanghai/plugins/test.py
@@ -1,6 +1,6 @@
 """Just for testing"""
 
-from shanghai.event import global_event, GlobalEventName
+from shanghai.event import global_event, GlobalEventName, ReturnValue
 
 __plugin_name__ = 'Test'
 __plugin_version__ = 'β.γ.μ'
@@ -29,3 +29,8 @@ async def init_context(ctx):
             if len(words) < 2:
                 return
             ctx.send_ctcp(message.prefix.name, words[1], ' '.join(words[2:]))
+
+        elif words[0] == '!eat':
+            if len(words) == 2:
+                return words[1]
+            return ReturnValue.EAT

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from shanghai import event
+from shanghai.logging import Logger
 
 
 @pytest.fixture
@@ -111,7 +112,7 @@ class TestPrioritizedSetList:
 class TestEventDispatchers:
 
     @pytest.fixture
-    def dispatcher(self,):
+    def dispatcher(self):
         return event.EventDispatcher()
 
     def test_register(self, dispatcher):
@@ -187,6 +188,53 @@ class TestEventDispatchers:
         dispatcher.register("name", coroutinefunc)
         loop.run_until_complete(dispatcher.dispatch(evt))
 
+        assert called
+
+    def test_dispatch_eat(self, loop):
+        logger = mock.Mock(Logger)
+        dispatcher = event.EventDispatcher(logger=logger)
+        called = False
+
+        async def coroutinefunc():
+            nonlocal called
+            called = True
+            return event.ReturnValue.EAT
+
+        dispatcher.register("name", coroutinefunc)
+        result = loop.run_until_complete(dispatcher.dispatch("name"))
+        assert result is event.ReturnValue.EAT
+        assert called
+
+    def test_dispatch_exception(self, loop):
+        logger = mock.Mock(Logger)
+        dispatcher = event.EventDispatcher(logger=logger)
+        called = False
+
+        async def coroutinefunc():
+            nonlocal called
+            called = True
+            raise ValueError("yeah")
+
+        dispatcher.register("name", coroutinefunc)
+        assert not logger.exception.called
+        loop.run_until_complete(dispatcher.dispatch("name"))
+        assert logger.exception.call_count == 1
+        assert called
+
+    def test_dispatch_unknown_return(self, loop):
+        logger = mock.Mock(Logger)
+        dispatcher = event.EventDispatcher(logger=logger)
+        called = False
+
+        async def coroutinefunc():
+            nonlocal called
+            called = True
+            return "some arbitrary value"
+
+        dispatcher.register("name", coroutinefunc)
+        assert not logger.warning.called
+        loop.run_until_complete(dispatcher.dispatch("name"))
+        assert logger.warning.call_count == 1
         assert called
 
 


### PR DESCRIPTION
Event handlers can now return a value of `shanghai.event.ReturnValue` to tell the dispatcher to either eat the event (and not call handlers for a lower priority) or do nothing. The "nothing" value must default to `None`.

Exceptions are now also fetched and logged from within the dispatcher instead of being propagated to the worker task (which also resulted in very long and ugly tracebacks).