### PR TITLE
Revise channel plugin

### DIFF
--- a/shanghai/core_plugins/channel.py
+++ b/shanghai/core_plugins/channel.py
@@ -17,8 +17,6 @@
 # along with Shanghai.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections import namedtuple
-import re
-import string
 
 from shanghai.event import global_event, GlobalEventName, EventDispatcher, Priority
 from shanghai.network import NetworkContext

--- a/shanghai/core_plugins/channel.py
+++ b/shanghai/core_plugins/channel.py
@@ -18,7 +18,7 @@
 
 from collections import namedtuple
 
-from shanghai.event import global_event, GlobalEventName, EventDispatcher, Priority
+from shanghai.event import global_event, GlobalEventName, EventDispatcher
 from shanghai.network import NetworkContext
 from shanghai.util import ShadowAttributesMixin
 from shanghai.irc import Prefix, ServerReply
@@ -179,7 +179,7 @@ async def on_part(ctx: NetworkContext, message: Message):
         return
 
     nick = message.prefix.name
-    ctx.remove_nick_from_channel(nick, lchannel)
+    ctx._remove_nick_from_channel(nick, lchannel)
 
 
 async def on_kick(ctx: NetworkContext, message: Message):
@@ -190,7 +190,7 @@ async def on_kick(ctx: NetworkContext, message: Message):
         return
 
     kicked = message.params[1]
-    ctx.remove_nick_from_channel(kicked, lchannel)
+    ctx._remove_nick_from_channel(kicked, lchannel)
 
 
 async def on_nick(ctx: NetworkContext, message: Message):
@@ -221,7 +221,7 @@ async def on_quit(ctx: NetworkContext, message: Message):
 
 
 # Manipulation API
-def remove_nick_from_channel(ctx: NetworkContext, nick, channel):
+def _remove_nick_from_channel(ctx: NetworkContext, nick, channel):
     lnick = ctx.nick_lower(nick)
     lchannel = ctx.nick_lower(channel)
 
@@ -280,7 +280,7 @@ async def init_context(ctx: NetworkContext):
     # _joins is a relational table that connects channels and users
     ctx.add_attribute('_joins', {})  # (l(channel-name), l(nickname)) -> info_dict
 
-    ctx.add_method(remove_nick_from_channel)
+    ctx.add_method(_remove_nick_from_channel)
 
     ctx.message_event(ServerReply.RPL_NAMREPLY)(on_names)
     ctx.message_event(ServerReply.RPL_ENDOFNAMES)(on_names)

--- a/shanghai/core_plugins/channel.py
+++ b/shanghai/core_plugins/channel.py
@@ -271,7 +271,7 @@ def remove_nick_from_channel(ctx: NetworkContext, nick, channel):
             del ctx.users[lnick]
 
 
-@global_event(GlobalEventName.INIT_NETWORK_CTX, priority=Priority.POST_CORE)
+@global_event.core(GlobalEventName.INIT_NETWORK_CTX)
 async def init_context(ctx: NetworkContext):
     ctx.add_attribute('_collecting_names', set())  # l(channel-name)
 

--- a/shanghai/core_plugins/channel.py
+++ b/shanghai/core_plugins/channel.py
@@ -40,19 +40,18 @@ Channel.__new__.__defaults__ = (None,)
 
 class ChannelContext(ShadowAttributesMixin):
 
-    def __init__(self, network_context: NetworkContext, message: 'BaseMessage',
-                 *, logger: Logger=None):
+    def __init__(self, name, network_context: NetworkContext, *, logger: Logger=None):
+        self.name = name
         self.network_context = network_context
         self.network = network_context.network
-        self._message = message
 
         if logger is None:
-            logger = get_logger('channel', f'{self._message.channel}@{self.network.name}',
+            logger = get_logger('channel', f'{self.name}@{self.network.name}',
                                 self.network.config)
         self.logger = logger
 
     def say(self, message):
-        self.network_context.send_msg(self._message.channel, message)
+        self.network_context.send_msg(self.name, message)
 
     def msg(self, target, message):
         self.network_context.send_msg(target, message)
@@ -62,7 +61,7 @@ class ChannelContext(ShadowAttributesMixin):
         n_ctx = self.network_context
         member_list = []
         for lkey in n_ctx._joins:
-            if n_ctx.chan_eq(lkey[0], self._message.channel):
+            if n_ctx.chan_eq(lkey[0], self.name):
                 member_list.append(n_ctx.users[lkey[1]])
         return member_list
 
@@ -381,7 +380,7 @@ async def init_context(ctx: NetworkContext):
                 new_message = PrivateNotice.from_message(message)
 
         if lchannel not in channel_contexts:
-            c_ctx = ChannelContext(n_ctx, new_message)
+            c_ctx = ChannelContext(channel, n_ctx)
             channel_contexts[lchannel] = c_ctx
 
         await channel_event_dispatcher.dispatch(channel_contexts[lchannel], new_message)

--- a/shanghai/core_plugins/channel.py
+++ b/shanghai/core_plugins/channel.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Shanghai.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import namedtuple
 import re
 import string
 
@@ -31,6 +32,9 @@ __plugin_name__ = 'Channel'
 __plugin_version__ = '0.1.0'
 __plugin_description__ = 'Track channel state'
 __plugin_depends__ = ('message', 'options')
+
+
+Member = namedtuple('Member', 'prefix modes')
 
 
 class ChannelContext(ShadowAttributesMixin):
@@ -58,7 +62,8 @@ class ChannelContext(ShadowAttributesMixin):
         member_list = []
         for lkey in n_ctx._joins:
             if n_ctx.chan_eq(lkey[0], self.name):
-                member_list.append(n_ctx.users[lkey[1]])
+                member = Member(n_ctx.users[lkey[1]], **n_ctx._joins[lkey])
+                member_list.append(member)
         return member_list
 
 

--- a/shanghai/core_plugins/channel.py
+++ b/shanghai/core_plugins/channel.py
@@ -36,6 +36,7 @@ __plugin_depends__ = ('message',)
 class ChannelContext(ShadowAttributesMixin):
 
     def __init__(self, name, network_context: NetworkContext, *, logger: Logger=None):
+        super().__init__()
         self.name = name
         self.network_context = network_context
         self.network = network_context.network

--- a/shanghai/irc/message.py
+++ b/shanghai/irc/message.py
@@ -36,6 +36,9 @@ class Prefix(namedtuple("_Prefix", "name ident host")):
 
     __slots__ = ()
 
+    def __new__(cls, name, ident=None, host=None):
+        return super().__new__(cls, name, ident, host)
+
     @classmethod
     def from_string(cls, prefix: str) -> 'Prefix':
         name = prefix.lstrip(':')

--- a/shanghai/irc/options.py
+++ b/shanghai/irc/options.py
@@ -16,53 +16,126 @@
 # You should have received a copy of the GNU General Public License
 # along with Shanghai.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections.abc import MutableMapping
+import re
+import string
+
 from .message import Message
 from .server_reply import ServerReply
+
+
+DEFAULT_CASE_MAPPING = 'rfc1459'
+
+
+def _generate_case_table(case_mapping):
+    case_mapping = case_mapping.lower()
+    if case_mapping not in ('ascii', 'rfc1459', 'strict-rfc1459'):
+        # TODO log warning
+        case_mapping = DEFAULT_CASE_MAPPING
+    upper_str = string.ascii_uppercase
+    lower_str = string.ascii_lowercase
+    if case_mapping == 'rfc1459':
+        upper_str += "[]\\^"
+        lower_str += "{}|~"
+    elif case_mapping == 'strict-rfc1459':
+        upper_str += "[]\\"
+        lower_str += "{}|"
+    return str.maketrans(upper_str, lower_str)
 
 
 # TODO evaluate against specs
 # http://www.irc.org/tech_docs/005.html
 # http://www.irc.org/tech_docs/draft-brocklesby-irc-isupport-03.txt
-class Options:
-    """A simple case insensitive mapping of 005 RPL_ISUPPORT reply."""
-    _fields = ('_options',)
+class Options(MutableMapping):
+
+    """A case insensitive mapping of 005 RPL_ISUPPORT settings and convenience functions."""
+
+    user_modes = 'ov'
+    user_prefixes = '@+'
+    _case_table = _generate_case_table(DEFAULT_CASE_MAPPING)
 
     def __init__(self, **kwargs):
-        self._options = kwargs
+        self._options = {k.upper(): v for k, v in kwargs.items()}
 
     def __setitem__(self, key, value):
-        self._options[key.upper()] = value
+        ukey = key.upper()
+        self._options[ukey] = value
 
-    def __setattr__(self, key, value):
-        if key in self._fields:
-            super().__setattr__(key, value)
-        else:
-            self._options[key.upper()] = value
+        if ukey == 'PREFIX':
+            self._parse_prefix(value)
+        elif ukey == 'CASEMAPPING':
+            self._case_table = _generate_case_table(value)
 
     def __getitem__(self, item):
         return self._options[item.upper()]
 
-    def __getattr__(self, item):
-        return self._options[item.upper()]
+    def __delitem__(self, item):
+        del self._options[item.upper()]
+
+    def __iter__(self):
+        return iter(self._options)
+
+    def __len__(self):
+        return len(self._options)
 
     def __repr__(self):
-        text_list = [f"{self.__class__.__name__}("]
-        for key, value in sorted(self._options.items()):
-            text_list.append(f"    {key}={value!r},")
-        text_list.append(")")
-        return "\n".join(text_list)
+        params = ", ".join(f"{key}={value!r}"
+                           for key, value in sorted(self._options.items()))
+        return f"{self.__class__.__name__}({params})"
 
     def extend_from_message(self, message: Message):
         assert message.command == ServerReply.RPL_ISUPPORT
+        assert message.params[-1] == "are supported by this server"
+
         for option in message.params[1:-1]:
-            if '=' in option:
-                key, value = option.split('=', 1)
-            else:
-                key, value = option, True
+            key, is_not_bool, value = option.partition('=')
+            if not is_not_bool:
+                value = True
             self[key] = value
 
-    def get(self, item, default=None):
-        try:
-            return self[item]
-        except KeyError:
-            return default
+    def _parse_prefix(self, value):
+        if not value:
+            # empty value means no prefixes
+            self.user_modes = self.user_prefixes = ''
+            return
+
+        match = re.match(r'^\((.*)\)(.*)$', value)
+        if match is None:
+            # TODO log warning
+            pass
+        elif len(match.group(1)) != len(match.group(2)):
+            # TODO log warning
+            pass
+        else:
+            self.user_modes, self.user_modes = match.groups()
+
+    def split_prefixes(self, prefixed_nick):
+        nick = prefixed_nick
+        prefixes = ''
+        if self.get('NAMESX', False):
+            nick = prefixed_nick.lstrip(self.user_prefixes)
+            prefixes = prefixed_nick[:-len(nick)]
+        elif nick[0] in self.user_prefixes:
+            prefixes = prefixed_nick[0]
+            nick = prefixed_nick[1:]
+        return prefixes, nick
+
+    def prefixes_to_modes(self, prefixes):
+        table = str.maketrans(self.user_prefixes, self.user_modes)
+        return prefixes.translate(table)
+
+    def modes_to_prefixes(self, modes):
+        table = str.maketrans(self.user_modes, self.user_prefixes)
+        return modes.translate(table)
+
+    def nick_lower(self, nick: str):
+        return nick.translate(self._case_table)
+
+    def chan_lower(self, chan: str):
+        return self.nick_lower(chan)
+
+    def nick_eq(self, nick1: str, nick2: str):
+        return self.nick_lower(nick1) == self.nick_lower(nick2)
+
+    def chan_eq(self, chan1: str, chan2: str):
+        return self.chan_lower(chan1) == self.chan_lower(chan2)

--- a/shanghai/network.py
+++ b/shanghai/network.py
@@ -203,10 +203,6 @@ async def init_context(ctx):
             else:
                 ctx.send_cmd('JOIN', channel)
 
-    @ctx.message_event.core(ServerReply.RPL_ISUPPORT)
-    async def on_msg_isupport(ctx, message):
-        ctx.network.options.extend_from_message(message)
-
     @ctx.network_event.core(NetworkEventName.CONNECTED)
     async def register_connection(ctx, _):
         # testing

--- a/shanghai/plugins/test.py
+++ b/shanghai/plugins/test.py
@@ -33,10 +33,8 @@ async def channel_message(ctx, message):
         ctx.say(' '.join(unhighlight(member.name) for member in ctx.members))
 
     elif message.words[0] == '!channels':
-        chan_list = []
-        for chanobj in ctx.network_context.channels.values():
-            _c_ctx = ctx.network_context.get_channel_context(chanobj.name)
-            chan_list.append(f'{chanobj.name} ({len(_c_ctx.members)})')
+        chan_list = [f"{_c_ctx.name} ({len(_c_ctx.members)})"
+                     for _c_ctx in ctx.network_context.channels.values()]
         ctx.say(', '.join(chan_list))
 
 

--- a/shanghai/plugins/test.py
+++ b/shanghai/plugins/test.py
@@ -30,7 +30,16 @@ async def channel_message(ctx, message):
         return f'{nick[:1]}\N{ZERO WIDTH SPACE}{nick[1:]}'
 
     if message.words[0] == '!nicks':
-        ctx.say(' '.join(unhighlight(member.name) for member in ctx.members))
+        nick_list = [unhighlight(member.prefix.name)
+                     for member in ctx.members]
+        ctx.say(' '.join(nick_list))
+
+    if message.words[0] == '!names':
+        nick_list = []
+        for member in ctx.members:
+            prefixes = ctx.network_context.options.modes_to_prefixes(member.modes)
+            nick_list.append(f"{prefixes}{unhighlight(member.prefix.name)}")
+        ctx.say(' '.join(nick_list))
 
     elif message.words[0] == '!channels':
         chan_list = [f"{_c_ctx.name} ({len(_c_ctx.members)})"

--- a/shanghai/plugins/test.py
+++ b/shanghai/plugins/test.py
@@ -26,13 +26,11 @@ __plugin_description__ = 'bla blub'
 async def channel_message(ctx, message):
     ctx.logger.debug(f'Got a channel message {message}')
 
+    def unhighlight(nick):
+        return f'{nick[:1]}\N{ZERO WIDTH SPACE}{nick[1:]}'
+
     if message.words[0] == '!nicks':
-        nick_list = []
-        for member in ctx.members:
-            nick = member.nickname
-            nick = f'{nick[:1]}\N{ZERO WIDTH SPACE}{nick[1:]}'
-            nick_list.append(nick)
-        ctx.say(' '.join(nick_list))
+        ctx.say(' '.join(unhighlight(member.name) for member in ctx.members))
 
     elif message.words[0] == '!channels':
         chan_list = []

--- a/shanghai/plugins/test.py
+++ b/shanghai/plugins/test.py
@@ -80,3 +80,7 @@ async def init_context(ctx):
             if len(words) == 2:
                 return words[1]
             return ReturnValue.EAT
+
+        elif words[0] == '!quote':
+            _, line_to_send = line.split(maxsplit=1)
+            ctx.send_line(line_to_send)

--- a/shanghai/util.py
+++ b/shanghai/util.py
@@ -64,7 +64,8 @@ class ShadowAttributesMixin:
         # TODO test how hasattr performs with our __getattr__
         return name in self.__dict__ or name in self._added_attributes
 
-    def add_method(self, name_or_function: Union[str, Callable], function: Callable = None):
+    def add_method(self, name_or_function: Union[str, Callable], function: Callable = None,
+                   *, _static=False):
         """Allows to add methods to an object.
 
         Added functions will be called with an implicit `self` argment,
@@ -82,9 +83,20 @@ class ShadowAttributesMixin:
         else:
             name = name_or_function
 
-        self.add_attribute(name, functools.partial(function, self))
+        if not _static:
+            attr = functools.partial(function, self)
+        else:
+            attr = function
+        self.add_attribute(name, attr)
 
         return function
+
+    def add_staticmethod(self, name_or_function: Union[str, Callable], function: Callable = None):
+        """Allows to add staticmethods to an object.
+
+        Also functions as a decorator and infers the attribute name from the function name.
+        """
+        return self.add_method(name_or_function, function, _static=True)
 
     def remove_attribute(self, name: str):
         """Allows for plugins to remove their added attributes to the network object."""


### PR DESCRIPTION
Addresses a few of my remaining concerns mentioned in #46.  Note that this PR is against `dev/nitori`, not `master`.

- moved some stuff to `shanghai.irc.options.Options`
- added an `options.py` plugin
- normalized "relational database"
- removed all `_Base` classes
- renamed ctx attributes to reflect their "privateness"
- more minor stuff

I did not touch ChannelMessage (and private stuff) event generation.